### PR TITLE
fix: handle empty secondaryPath in SetupPage

### DIFF
--- a/src/views/SetupPage.vue
+++ b/src/views/SetupPage.vue
@@ -194,7 +194,7 @@ if (query.has('hostname')) {
       : query.get('https')
         ? 'https'
         : window.location.protocol.replace(':', ''),
-    secondaryPath: query.get('secondaryPath') as string,
+    secondaryPath: (query.get('secondaryPath') as string) || '',
     host: query.get('hostname') as string,
     port: Number(query.get('port')),
     password: query.get('secret') as string,


### PR DESCRIPTION
修正url中不包含`secondaryPath`参数时报错`TypeError: URL is not valid or contains user credentials.`的问题

例如`http://192.168.0.1:9090/ui/zashboard/?hostname=192.168.0.1&port=9090&secret=123`

<img width="1454" alt="image" src="https://github.com/user-attachments/assets/046ca569-25c7-4f6d-a02e-7cda806dadc2">
