### PR TITLE
feat: add `/setup` route for SetupPage

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -3,7 +3,6 @@ import {
   Cog6ToothIcon,
   DocumentTextIcon,
   GlobeAltIcon,
-  PlayIcon,
   WrenchScrewdriverIcon,
 } from '@heroicons/vue/24/outline'
 
@@ -95,7 +94,6 @@ export enum ROUTE_NAME {
   logs = 'logs',
   rules = 'rules',
   settings = 'settings',
-  setup = 'setup',
 }
 
 export const ROUTE_ICON_MAP = {
@@ -104,5 +102,4 @@ export const ROUTE_ICON_MAP = {
   [ROUTE_NAME.rules]: WrenchScrewdriverIcon,
   [ROUTE_NAME.logs]: DocumentTextIcon,
   [ROUTE_NAME.settings]: Cog6ToothIcon,
-  [ROUTE_NAME.setup]: PlayIcon,
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -3,6 +3,7 @@ import {
   Cog6ToothIcon,
   DocumentTextIcon,
   GlobeAltIcon,
+  PlayIcon,
   WrenchScrewdriverIcon,
 } from '@heroicons/vue/24/outline'
 
@@ -94,6 +95,7 @@ export enum ROUTE_NAME {
   logs = 'logs',
   rules = 'rules',
   settings = 'settings',
+  setup = 'setup',
 }
 
 export const ROUTE_ICON_MAP = {
@@ -102,4 +104,5 @@ export const ROUTE_ICON_MAP = {
   [ROUTE_NAME.rules]: WrenchScrewdriverIcon,
   [ROUTE_NAME.logs]: DocumentTextIcon,
   [ROUTE_NAME.settings]: Cog6ToothIcon,
+  [ROUTE_NAME.setup]: PlayIcon,
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -42,7 +42,7 @@ const router = createRouter({
     },
     {
       path: '/setup',
-      name: ROUTE_NAME.setup,
+      name: 'setup',
       component: SetupPage,
     },
     {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -7,6 +7,7 @@ import LogsPage from '@/views/LogsPage.vue'
 import ProxiesPage from '@/views/ProxiesPage.vue'
 import RulesPage from '@/views/RulesPage.vue'
 import SettingsPage from '@/views/SettingsPage.vue'
+import SetupPage from '@/views/SetupPage.vue'
 import { useTitle } from '@vueuse/core'
 import { watch } from 'vue'
 import { createRouter, createWebHashHistory } from 'vue-router'
@@ -38,6 +39,11 @@ const router = createRouter({
       path: '/settings',
       name: ROUTE_NAME.settings,
       component: SettingsPage,
+    },
+    {
+      path: '/setup',
+      name: ROUTE_NAME.setup,
+      component: SetupPage,
     },
     {
       path: '/:catchAll(.*)',


### PR DESCRIPTION
Zashboard has support for setting up backend using query params (`hostname=xxx&secret=xxx`). However this feature requires the SetupPage component to be activated. And currently there is no way to invoke that component using URL only. As a result, when there is already some backend configured, one has to manually click "+" icon, then enter that URL, so that a new backend could be added.

Also, after setting up multiple backends, there is no way to switch between them using URL.

Therefore, this PR adds `/setup` route to solve both issues.

With this PR, `/setup?hostname=xxx` will setup backend (if it does not exists already) and then switch to it. Similar to what metacubexd does.