### PR TITLE
chore: unified display style for proxies quantity

### DIFF
--- a/src/components/proxies/ProxyGroup.vue
+++ b/src/components/proxies/ProxyGroup.vue
@@ -121,11 +121,7 @@ const availableProxies = computed(() => {
 
 const proxiesCount = computed(() => {
   const all = proxyGroup.value.all?.length ?? 0
-
-  if (availableProxies.value < all) {
-    return `${availableProxies.value}/${all}`
-  }
-  return all
+  return `${availableProxies.value}/${all}`
 })
 
 const isLatencyTesting = ref(false)

--- a/src/components/proxies/ProxyProvider.vue
+++ b/src/components/proxies/ProxyProvider.vue
@@ -98,11 +98,7 @@ const availableProxies = computed(() => {
 })
 const proxiesCount = computed(() => {
   const all = proxyProvider.value.proxies?.length ?? 0
-
-  if (availableProxies.value < all) {
-    return `${availableProxies.value}/${all}`
-  }
-  return all
+  return `${availableProxies.value}/${all}`
 })
 
 const subscriptionInfo = computed(() => {


### PR DESCRIPTION
当前，Issue #246 里 `total` 的含义是 **所有节点**，所有代理组均显示为 `alive / total` 更统一