### PR TITLE
Fix font names of `system-ui`

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -6,11 +6,11 @@
 }
 
 @theme {
-  --font-MiSans: 'MiSans-VF', 'NotoEmoji', 'system-ui';
-  --font-SarasaUI: 'SarasaUiSC-Regular', 'NotoEmoji', 'system-ui';
-  --font-PingFang: 'PingFangSC-Regular', 'NotoEmoji', 'system-ui';
-  --font-FiraSans: 'Fira Sans', 'NotoEmoji', 'system-ui';
-  --font-SystemUI: 'NotoEmoji', 'system-ui';
+  --font-MiSans: 'MiSans-VF', 'NotoEmoji', system-ui;
+  --font-SarasaUI: 'SarasaUiSC-Regular', 'NotoEmoji', system-ui;
+  --font-PingFang: 'PingFangSC-Regular', 'NotoEmoji', system-ui;
+  --font-FiraSans: 'Fira Sans', 'NotoEmoji', system-ui;
+  --font-SystemUI: 'NotoEmoji', system-ui;
 }
 
 @layer utilities {


### PR DESCRIPTION
The documentation of `font-family` states that [`<generic-name>`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#generic-name) values should not be quoted:

> Generic family names are keywords and must not be quoted.

Quoting them will make them to be interpreted as a font named "system-ui" instead of the default user interface font, in which case the browser will not be able to find the font.