### PR TITLE
fix: add replace option to router push for consistent navigation behavior when running in mobile browser or in webui app like ksu

### DIFF
--- a/src/composables/swipe.ts
+++ b/src/composables/swipe.ts
@@ -26,7 +26,7 @@ export const useSwipeRouter = () => {
               return [
                 () => route.name === ROUTE_NAME.proxies && proxiesTabShow.value === tab,
                 () => {
-                  router.push({ name: ROUTE_NAME.proxies })
+                  router.push({ name: ROUTE_NAME.proxies, replace: true })
                   proxiesTabShow.value = tab
                 },
               ]
@@ -36,7 +36,7 @@ export const useSwipeRouter = () => {
               return [
                 () => route.name === ROUTE_NAME.connections && connectionTabShow.value === tab,
                 () => {
-                  router.push({ name: ROUTE_NAME.connections })
+                  router.push({ name: ROUTE_NAME.connections, replace: true })
                   connectionTabShow.value = tab
                 },
               ]
@@ -46,7 +46,7 @@ export const useSwipeRouter = () => {
               return [
                 () => route.name === ROUTE_NAME.rules && rulesTabShow.value === tab,
                 () => {
-                  router.push({ name: ROUTE_NAME.rules })
+                  router.push({ name: ROUTE_NAME.rules, replace: true })
                   rulesTabShow.value = tab
                 },
               ]
@@ -54,7 +54,7 @@ export const useSwipeRouter = () => {
           }
         }
 
-        return [[() => route.name === r, () => router.push({ name: r })]]
+        return [[() => route.name === r, () => router.push({ name: r, replace: true })]]
       }),
     )
   })
@@ -67,7 +67,7 @@ export const useSwipeRouter = () => {
     const routeName = route.name as ROUTE_NAME
 
     if (routeName === ROUTE_NAME.setup) {
-      return router.push({ name: ROUTE_NAME.proxies })
+      return router.push({ name: ROUTE_NAME.proxies, replace: true })
     }
 
     return swipeList.value[(getNextIndexInSwipeList() + 1) % swipeList.value.length]?.[1]?.()
@@ -76,7 +76,7 @@ export const useSwipeRouter = () => {
     const routeName = route.name as ROUTE_NAME
 
     if (routeName === ROUTE_NAME.setup) {
-      return router.push({ name: ROUTE_NAME.proxies })
+      return router.push({ name: ROUTE_NAME.proxies, replace: true })
     }
 
     return swipeList.value[

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -34,7 +34,7 @@
             <button
               v-for="r in renderRoutes"
               :key="r"
-              @click="router.push({ name: r })"
+              @click="router.push({ name: r, replace: true })"
               class="h-14 flex-col items-center justify-center pt-2"
               :class="r === route.name && 'dock-active'"
             >


### PR DESCRIPTION
In mobile browsers or the KSU app, after click the navigation bar multiple times requires clicking the back button many times to exit `zashboard`, which contradicts with the navigation bar on mobile devices.