### PR TITLE
feat:添加后端时默认同步内核面板设置

### DIFF
--- a/src/views/SetupPage.vue
+++ b/src/views/SetupPage.vue
@@ -141,6 +141,7 @@ import TextInput from '@/components/common/TextInput.vue'
 import EditBackendModal from '@/components/settings/backend/EditBackendModal.vue'
 import LanguageSelect from '@/components/settings/general/LanguageSelect.vue'
 import { ROUTE_NAME } from '@/constant'
+import { syncSettingsFromCore } from '@/helper/autoImportSettings'
 import { showNotification } from '@/helper/notification'
 import { getBackendFromUrl, getLabelFromBackend, getUrlFromBackend } from '@/helper/utils'
 import router from '@/router'
@@ -235,6 +236,11 @@ const handleSubmit = async (form: Omit<Backend, 'uuid'>, quiet = false) => {
     }
 
     addBackend(form)
+    const synced = await syncSettingsFromCore()
+    if (synced) {
+      return
+    }
+
     router.push({ name: ROUTE_NAME.proxies })
   } catch (e) {
     if (!quiet) {


### PR DESCRIPTION
概要
这个 PR 调整了新增后端的流程：当后端验证成功并添加后，会先从当前激活的后端同步面板设置，再进入主界面。

背景
之前新增后端后，界面可能先使用本地或默认设置加载，随后才应用后端中的面板设置。现在改为先同步设置，可以让首次进入界面时就使用后端配置。

这个改动对后端 IP 经常变化的场景尤其有用：用户通过新地址重新添加后端时，可以直接从该后端恢复/同步已有面板设置，减少重复配置和进入界面后的状态不一致。