### PR TITLE
feat(ui): single-line logs and rules with smooth expand animation

### DIFF
--- a/src/assets/styles/override.css
+++ b/src/assets/styles/override.css
@@ -176,3 +176,7 @@
     }
   }
 }
+
+.rule-move-move {
+  transition: transform 300ms ease;
+}

--- a/src/components/logs/LogsCard.vue
+++ b/src/components/logs/LogsCard.vue
@@ -1,37 +1,35 @@
 <template>
   <div
-    class="scroller-item hover:bg-base-200/40 flex flex-col gap-2 px-3 py-2 text-sm transition-colors"
+    class="scroller-item hover:bg-base-200/40 flex items-center gap-2 truncate px-3 py-1 text-sm transition-colors"
+    :title="log.payload"
   >
-    <div class="flex items-center gap-2">
-      <span
-        class="text-base-content/40 text-xs tabular-nums"
-        :style="{ minWidth: `${(seqWithPadding.length + 1) * 0.62}em` }"
-      >
-        {{ seqWithPadding }}
-      </span>
-      <span
-        class="badge badge-sm"
-        :class="colorMapForType[log.type as keyof typeof colorMapForType]"
-      >
-        <HighlightText
-          :text="log.type"
-          :filter="logFilter"
-        />
-      </span>
-      <div class="flex-1"></div>
-      <span class="text-base-content/40 text-xs tabular-nums">
-        <HighlightText
-          :text="log.time"
-          :filter="logFilter"
-        />
-      </span>
-    </div>
-    <div class="w-full leading-relaxed break-words">
+    <span
+      class="text-base-content/40 shrink-0 text-xs tabular-nums"
+      :style="{ minWidth: `${(seqWithPadding.length + 1) * 0.62}em` }"
+    >
+      {{ seqWithPadding }}
+    </span>
+    <span
+      class="badge badge-sm shrink-0"
+      :class="colorMapForType[log.type as keyof typeof colorMapForType]"
+    >
+      <HighlightText
+        :text="log.type"
+        :filter="logFilter"
+      />
+    </span>
+    <span class="text-base-content/40 shrink-0 text-xs tabular-nums">
+      <HighlightText
+        :text="log.time"
+        :filter="logFilter"
+      />
+    </span>
+    <span class="truncate">
       <HighlightText
         :text="log.payload"
         :filter="logFilter"
       />
-    </div>
+    </span>
   </div>
 </template>
 

--- a/src/components/rules/RuleCard.vue
+++ b/src/components/rules/RuleCard.vue
@@ -1,17 +1,17 @@
 <template>
   <div :class="{ 'opacity-50': isDisabled, 'scroller-item': 1 }">
     <div
-      class="hover:bg-base-200/40 flex flex-col gap-3 overflow-hidden px-3 py-2 text-sm transition-colors"
+      class="hover:bg-base-200/40 flex items-center gap-2 overflow-hidden px-3 py-2 text-sm transition-colors"
       :class="{
         'cursor-pointer': isSelectable,
       }"
       @click="clickHandler"
     >
-      <div class="min-h-5 leading-5">
+      <div class="min-w-0 flex-1 truncate">
         <span class="text-base-content/50 text-xs tabular-nums">
           {{ index }}
         </span>
-        <span class="text-base-content/80 ml-4 text-xs">
+        <span class="text-base-content/80 ml-3 text-xs">
           <HighlightText
             :text="rule.type"
             :filter="rulesFilter"
@@ -19,8 +19,8 @@
           <template v-if="rule.payload"> : </template>
         </span>
         <span
-          class="ml-2"
           v-if="rule.payload"
+          class="ml-1"
         >
           <HighlightText
             :text="rule.payload"
@@ -38,18 +38,6 @@
             @mouseenter="showMMDBSizeTip"
           />
         </span>
-        <button
-          v-if="isUpdateableRuleSet"
-          :class="
-            twMerge(
-              'btn btn-circle btn-ghost btn-xs -mt-[2px] ml-1',
-              isUpdating ? 'animate-spin' : '',
-            )
-          "
-          @click.stop="updateRuleProviderClickHandler"
-        >
-          <ArrowPathIcon class="h-3.5 w-3.5 opacity-60" />
-        </button>
         <InformationCircleIcon
           v-if="rule.extra"
           class="-mt-[2px] ml-1 inline-block h-4 w-4 opacity-60"
@@ -57,36 +45,56 @@
           @click.stop
         />
       </div>
-      <div class="flex items-center gap-2">
-        <input
-          v-if="rule.uuid || rule.extra"
-          type="checkbox"
-          class="toggle toggle-sm"
-          :checked="!isDisabled"
-          @change="toggleRuleDisabledHandler"
-          @click.stop
-        />
+      <div class="max-w-[50%] min-w-0 shrink">
         <ProxyChainPath
           :proxy="rule.proxy"
           :selected="selected"
-          :collapsed="isCollapsed"
           :show-now-node="displayNowNodeInRule"
           :show-latency="displayLatencyInRule"
           :filter="rulesFilter"
-          :interactive="!isCollapsed"
           @update:selected="selected = $event"
         />
       </div>
+      <input
+        v-if="rule.uuid || rule.extra"
+        type="checkbox"
+        class="toggle toggle-sm shrink-0"
+        :checked="!isDisabled"
+        @change="toggleRuleDisabledHandler"
+        @click.stop
+      />
+      <button
+        :class="
+          twMerge(
+            'btn btn-circle btn-ghost btn-xs shrink-0',
+            isUpdating ? 'animate-spin' : '',
+            isUpdateableRuleSet ? '' : 'pointer-events-none invisible',
+          )
+        "
+        :aria-hidden="!isUpdateableRuleSet"
+        :tabindex="isUpdateableRuleSet ? 0 : -1"
+        @click.stop="updateRuleProviderClickHandler"
+      >
+        <ArrowPathIcon class="h-3.5 w-3.5 opacity-60" />
+      </button>
     </div>
 
-    <template v-if="isSelectable && !isCollapsed">
-      <div class="border-base-content/3 border-b"></div>
-      <ProxyGroup
-        :name="selected"
-        :force-open="true"
-        class="transparent-collapse bg-base-200/40! rounded-none!"
-      />
-    </template>
+    <div
+      class="transparent-collapse bg-base-200/40! collapse rounded-none!"
+      :class="isSelectable && !isCollapsed ? 'collapse-open' : 'collapse-close'"
+    >
+      <div
+        v-if="isSelectable"
+        class="collapse-content p-0!"
+      >
+        <div class="border-base-content/3 border-b"></div>
+        <ProxyGroup
+          :name="selected"
+          :force-open="true"
+          class="transparent-collapse bg-base-200/40! rounded-none!"
+        />
+      </div>
+    </div>
   </div>
 </template>
 

--- a/src/views/LogsPage.vue
+++ b/src/views/LogsPage.vue
@@ -2,7 +2,7 @@
   <div class="relative size-full overflow-x-hidden">
     <VirtualScroller
       :data="renderLogs"
-      :size="44"
+      :size="38"
     >
       <template v-slot:before>
         <LogsCtrl />

--- a/src/views/RulesPage.vue
+++ b/src/views/RulesPage.vue
@@ -17,21 +17,25 @@
           </div>
         </template>
         <template v-else>
-          <div class="base-container">
+          <TransitionGroup
+            name="rule-move"
+            tag="div"
+            class="base-container"
+          >
             <RuleCard
               v-for="rule in renderRules"
               :key="rule.payload"
               :rule="rule"
               :index="rules.indexOf(rule) + 1"
             />
-          </div>
+          </TransitionGroup>
         </template>
       </div>
     </template>
     <VirtualScroller
       v-else
       :data="renderRules"
-      :size="44"
+      :size="40"
     >
       <template v-slot:before>
         <RulesCtrl />


### PR DESCRIPTION
- Logs: render each entry on one line (seq, type, time, payload) with 4px vertical padding; truncate long payloads with hover title.
- Rules: compact single-line layout (info, proxy chain, toggle, refresh), 8px vertical padding, refresh button keeps a placeholder slot so the toggle stays aligned across rows. Proxy chain is always shown in full and scrolls horizontally when overflowing.
- Rules expand/collapse via daisyUI collapse (matches node groups) and subsequent rules animate to their new position via TransitionGroup FLIP.