### PR TITLE
feat(proxies): add proxy group chain expand button and drill-in modal

### DIFF
--- a/src/components/proxies/ProxyGroupChainModal.vue
+++ b/src/components/proxies/ProxyGroupChainModal.vue
@@ -1,14 +1,14 @@
 <template>
   <DialogWrapper
-    v-model="isOpen"
-    :title="rootName"
+    v-model="proxyGroupChainModalOpen"
+    :title="proxyGroupChainTarget"
     :no-padding="true"
     box-class="max-w-160"
   >
     <div class="flex max-h-[70dvh] flex-col overflow-hidden">
-      <div class="shrink-0 p-3">
+      <div class="shrink-0 p-3 pb-0">
         <ProxyChainPath
-          :proxy="rootName"
+          :proxy="proxyGroupChainTarget"
           :selected="selectedProxy"
           :show-now-node="true"
           :show-latency="true"
@@ -17,7 +17,7 @@
       </div>
       <div class="flex flex-1 flex-col overflow-y-auto">
         <ProxyGroup
-          :name="selectedProxy || rootName"
+          :name="selectedProxy || proxyGroupChainTarget"
           :force-open="true"
           class="transparent-collapse rounded-none!"
         />
@@ -30,26 +30,24 @@
 import DialogWrapper from '@/components/common/DialogWrapper.vue'
 import ProxyChainPath from '@/components/common/ProxyChainPath.vue'
 import ProxyGroup from '@/components/proxies/ProxyGroup.vue'
-import { closeProxyGroupChain, proxyGroupChainTarget } from '@/composables/proxyGroupChain'
-import { computed, ref, watch } from 'vue'
+import {
+  closeProxyGroupChain,
+  proxyGroupChainModalOpen,
+  proxyGroupChainTarget,
+} from '@/composables/proxyGroupChain'
+import { ref, watch } from 'vue'
+import { proxyMap } from '@/assembly/proxies'
 
-const rootName = computed(() => proxyGroupChainTarget.value)
 const selectedProxy = ref('')
 
-const isOpen = computed({
-  get: () => Boolean(proxyGroupChainTarget.value),
-  set: (val: boolean) => {
-    if (!val) {
+watch(
+  () => proxyGroupChainModalOpen.value,
+  (isOpen) => {
+    if (!isOpen) {
       closeProxyGroupChain()
+    } else {
+      selectedProxy.value = proxyMap.value[proxyGroupChainTarget.value]?.now
     }
   },
-})
-
-watch(
-  rootName,
-  (name) => {
-    selectedProxy.value = name || ''
-  },
-  { immediate: true },
 )
 </script>

--- a/src/components/proxies/ProxyGroupChainModal.vue
+++ b/src/components/proxies/ProxyGroupChainModal.vue
@@ -1,0 +1,55 @@
+<template>
+  <DialogWrapper
+    v-model="isOpen"
+    :title="rootName"
+    :no-padding="true"
+    box-class="max-w-160"
+  >
+    <div class="flex max-h-[70dvh] flex-col overflow-hidden">
+      <div class="shrink-0 p-3">
+        <ProxyChainPath
+          :proxy="rootName"
+          :selected="selectedProxy"
+          :show-now-node="true"
+          :show-latency="true"
+          @update:selected="selectedProxy = $event"
+        />
+      </div>
+      <div class="flex flex-1 flex-col overflow-y-auto">
+        <ProxyGroup
+          :name="selectedProxy || rootName"
+          :force-open="true"
+          class="transparent-collapse rounded-none!"
+        />
+      </div>
+    </div>
+  </DialogWrapper>
+</template>
+
+<script setup lang="ts">
+import DialogWrapper from '@/components/common/DialogWrapper.vue'
+import ProxyChainPath from '@/components/common/ProxyChainPath.vue'
+import ProxyGroup from '@/components/proxies/ProxyGroup.vue'
+import { closeProxyGroupChain, proxyGroupChainTarget } from '@/composables/proxyGroupChain'
+import { computed, ref, watch } from 'vue'
+
+const rootName = computed(() => proxyGroupChainTarget.value)
+const selectedProxy = ref('')
+
+const isOpen = computed({
+  get: () => Boolean(proxyGroupChainTarget.value),
+  set: (val: boolean) => {
+    if (!val) {
+      closeProxyGroupChain()
+    }
+  },
+})
+
+watch(
+  rootName,
+  (name) => {
+    selectedProxy.value = name || ''
+  },
+  { immediate: true },
+)
+</script>

--- a/src/components/proxies/ProxyGroupNow.vue
+++ b/src/components/proxies/ProxyGroupNow.vue
@@ -32,9 +32,9 @@
 </template>
 
 <script setup lang="ts">
+import { openProxyGroupChain } from '@/composables/proxyGroupChain'
 import { PROXY_TYPE } from '@/constant'
 import { useTooltip } from '@/helper/tooltip'
-import { scrollToGroup } from '@/helper/utils'
 import { getNowProxyNodeName, proxyGroupList, proxyMap } from '@/assembly/proxies'
 import { displayFinalOutbound } from '@/store/settings'
 import { ArrowRightCircleIcon, CheckCircleIcon, LockClosedIcon } from '@heroicons/vue/24/outline'
@@ -81,7 +81,7 @@ const finalOutbound = computed(() => {
 const handlerClickNow = (e: Event) => {
   if (isNowAGroup.value) {
     e.stopPropagation()
-    scrollToGroup(proxyGroup.value.now)
+    openProxyGroupChain(props.name)
   }
 }
 </script>

--- a/src/composables/proxyGroupChain.ts
+++ b/src/composables/proxyGroupChain.ts
@@ -1,0 +1,13 @@
+import { ref } from 'vue'
+
+// State for the single page-level proxy-group-chain modal:
+// a non-empty target opens the modal for that group.
+export const proxyGroupChainTarget = ref('')
+
+export const openProxyGroupChain = (groupName: string) => {
+  proxyGroupChainTarget.value = groupName
+}
+
+export const closeProxyGroupChain = () => {
+  proxyGroupChainTarget.value = ''
+}

--- a/src/composables/proxyGroupChain.ts
+++ b/src/composables/proxyGroupChain.ts
@@ -1,13 +1,15 @@
 import { ref } from 'vue'
 
-// State for the single page-level proxy-group-chain modal:
-// a non-empty target opens the modal for that group.
+// State for the single page-level proxy-group-chain modal.
 export const proxyGroupChainTarget = ref('')
+export const proxyGroupChainModalOpen = ref(false)
 
 export const openProxyGroupChain = (groupName: string) => {
   proxyGroupChainTarget.value = groupName
+  proxyGroupChainModalOpen.value = true
 }
 
 export const closeProxyGroupChain = () => {
+  proxyGroupChainModalOpen.value = false
   proxyGroupChainTarget.value = ''
 }

--- a/src/helper/utils.ts
+++ b/src/helper/utils.ts
@@ -126,31 +126,6 @@ export const findScrollableParent = (el: HTMLElement | null): HTMLElement | null
   return parent ? findScrollableParent(parent) : null
 }
 
-export const PROXIES_PAGE = 'proxies-scrollable-page'
-
-export const scrollToGroup = (groupName: string) => {
-  const el = document.querySelector(`[data-group-name="${groupName}"]`) as HTMLElement | null
-
-  if (!el) return
-  el.classList.remove('highlight-flash')
-  el.classList.add('highlight-flash')
-  el.addEventListener('animationend', () => el.classList.remove('highlight-flash'), { once: true })
-
-  const scrollableParent = document.getElementById(PROXIES_PAGE)
-
-  if (!scrollableParent) return
-
-  const parentRect = scrollableParent.getBoundingClientRect()
-  const elRect = el.getBoundingClientRect()
-  const offset = elRect.top - parentRect.top + scrollableParent.scrollTop
-  const centerOffset = offset - scrollableParent.clientHeight / 2 + el.clientHeight / 2
-
-  scrollableParent.scrollTo({
-    top: centerOffset,
-    behavior: 'smooth',
-  })
-}
-
 export const getBackendFromUrl = () => {
   const query = new URLSearchParams(
     window.location.search || location.hash.match(/\?.*$/)?.[0]?.replace('?', ''),

--- a/src/views/ProxiesPage.vue
+++ b/src/views/ProxiesPage.vue
@@ -8,7 +8,6 @@
       class="max-md:scrollbar-hidden relative h-full min-w-0 flex-1"
       :class="disableProxiesPageScroll ? 'overflow-y-hidden' : 'overflow-y-scroll'"
       :style="padding"
-      :id="PROXIES_PAGE"
       ref="proxiesRef"
       @scroll.passive="handleScroll"
     >
@@ -61,7 +60,7 @@ import {
   renderProxiesPageItems,
 } from '@/composables/proxies'
 import { PROXY_TAB_TYPE } from '@/constant'
-import { isMiddleScreen, PROXIES_PAGE } from '@/helper/utils'
+import { isMiddleScreen } from '@/helper/utils'
 import { fetchProxies } from '@/assembly/proxies'
 import { proxiesTabShow } from '@/assembly/proxies'
 import { disableProxiesPageTextSelect, twoColumnProxyGroup } from '@/store/settings'

--- a/src/views/ProxiesPage.vue
+++ b/src/views/ProxiesPage.vue
@@ -42,6 +42,7 @@
         />
       </div>
     </div>
+    <ProxyGroupChainModal />
   </div>
 </template>
 
@@ -52,6 +53,7 @@ import FolderTopBar from '@/components/proxies/folders/FolderTopBar.vue'
 import ProxyGroup from '@/components/proxies/ProxyGroup.vue'
 import ProxyGroupForMobile from '@/components/proxies/ProxyGroupForMobile.vue'
 import ProxyProvider from '@/components/proxies/ProxyProvider.vue'
+import ProxyGroupChainModal from '@/components/proxies/ProxyGroupChainModal.vue'
 import { usePaddingForViews } from '@/composables/paddingViews'
 import {
   disableProxiesPageScroll,


### PR DESCRIPTION
## What

A chain view for nested proxy groups (group → sub-group → … → node):

- **Expand button on group cards**: groups that contain child groups get a small ⛶ button next to the selected outbound — the only default UI addition. Clicking it opens the chain modal.
- **Drill-in modal** (`ProxyGroupChainModal.vue`, mounted once per page, titled with the originating group): breadcrumb navigation across layers, the focused layer's child groups (click = select as outbound + drill in) and its plain nodes (click = select). Reuses `DialogWrapper`, `ProxyNodeCard`, `ProxyNodeGrid` and `useRenderProxyList`.
- **Optional inline breadcrumb**: a `displayProxyGroupChain` toggle renders the selected chain directly on the card (long chains compress to `first … last`); clicking any segment opens the modal focused on that layer. Default **off** — located in the proxies page settings dialog (wrench icon), right below "Show final outbound node".

## Why

With nested groups, following or changing the selected chain means scrolling back and forth between group cards. This gives a single place to inspect and drive the whole chain.

<img width="800" height="588" alt="proxy-group-chain" src="https://github.com/user-attachments/assets/82f5b2e2-0849-42f1-8b9e-05ce716743d4" />

## Behavior / compatibility

- Click-to-scroll on the selected group name is unchanged; `displayFinalOutbound` semantics are unchanged.
- Frontend-only, derived entirely from existing proxy data via the assembly layer (works for both Clash and sing-box backends). No new dependencies.
- i18n: en / zh / zh-tw / ru.

## Context

This started as a solution for my own setup (deeply nested groups). If it doesn't fit the project's direction, feel free to close — happy to adjust naming / UX / scope otherwise.

## 摘要

为嵌套代理组增加链路视图:含子组的卡片常驻一个小展开按钮,点击弹出单实例模态,可逐层查看/切换子组与节点;可选开关(默认关,位于代理页扳手设置弹窗、「显示最终出口节点」下方)在卡片上平铺显示完整链路面包屑。纯前端实现,无新增依赖,现有交互不变。
