### PR TITLE
fix: stop backend streams when active backend is cleared

### DIFF
--- a/src/assembly/logs/index.ts
+++ b/src/assembly/logs/index.ts
@@ -30,3 +30,8 @@ export const initLogs = () => {
     subscription.close()
   }
 }
+
+export const stopLogs = () => {
+  cancel?.()
+  cancel = undefined
+}

--- a/src/store/connections.ts
+++ b/src/store/connections.ts
@@ -56,7 +56,7 @@ export const isPaused = ref(false)
 export const downloadTotal = ref(0)
 export const uploadTotal = ref(0)
 
-let cancel: () => void
+let cancel: (() => void) | undefined
 
 export const initConnections = () => {
   cancel?.()
@@ -106,6 +106,11 @@ export const initConnections = () => {
     unwatch()
     ws.close()
   }
+}
+
+export const stopConnections = () => {
+  cancel?.()
+  cancel = undefined
 }
 
 const isDesc = computed(() => {

--- a/src/store/logs.ts
+++ b/src/store/logs.ts
@@ -3,7 +3,7 @@ import { useStorage } from '@vueuse/core'
 import { ref } from 'vue'
 
 // 完整的 logs ref 与流控状态(暂停 / 级别)由组装层维护并组装,store 仅直接引用,不再参与组装。
-export { initLogs, isPaused, logLevel, logs } from '@/assembly/logs'
+export { initLogs, isPaused, logLevel, logs, stopLogs } from '@/assembly/logs'
 
 // 纯视图侧的筛选状态(在 LogsPage 中过滤渲染,不参与日志组装)。
 export const logFilter = ref('')

--- a/src/store/overview.ts
+++ b/src/store/overview.ts
@@ -33,7 +33,7 @@ export const uploadSpeed = ref<number>(0)
 export const downloadSpeedHistory = ref(makeInitValue())
 export const uploadSpeedHistory = ref(makeInitValue())
 
-let cancel: () => void
+let cancel: (() => void) | undefined
 
 export const initSatistic = () => {
   cancel?.()
@@ -115,4 +115,9 @@ export const initSatistic = () => {
     unwatchMemory()
     unwatchTraffic()
   }
+}
+
+export const stopSatistic = () => {
+  cancel?.()
+  cancel = undefined
 }

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -111,9 +111,9 @@ import { renderRoutes } from '@/helper'
 import { showNotification } from '@/helper/notification'
 import { getLabelFromBackend, isMiddleScreen } from '@/helper/utils'
 import { fetchConfigs } from '@/assembly/config'
-import { initConnections } from '@/store/connections'
-import { initLogs } from '@/store/logs'
-import { initSatistic } from '@/store/overview'
+import { initConnections, stopConnections } from '@/store/connections'
+import { initLogs, stopLogs } from '@/store/logs'
+import { initSatistic, stopSatistic } from '@/store/overview'
 import { fetchProxies, resetProxies } from '@/assembly/proxies'
 import { proxiesTabShow } from '@/assembly/proxies'
 import { fetchRules, rulesTabShow } from '@/assembly/rules'
@@ -163,7 +163,14 @@ watch(
   activeUuid,
   async () => {
     await resetProxies()
-    if (!activeUuid.value) return
+    if (!activeUuid.value) {
+      // 后端被清空(登出 / 401 / 新增后端)时关闭常驻流,
+      // 否则它们会以无主状态留在 Setup 页继续运行并无限重连。
+      stopConnections()
+      stopLogs()
+      stopSatistic()
+      return
+    }
     rulesTabShow.value = RULE_TAB_TYPE.RULES
     proxiesTabShow.value = PROXY_TAB_TYPE.PROXIES
     fetchConfigs()


### PR DESCRIPTION
修复:activeUuid 被清空(退出登录 / 401 自动登出 / 「新增后端」跳转 Setup)时,HomePage 的 watcher 直接 return,connections/logs/traffic/memory 四条流的 cancel 存在模块级变量里、再无代码能触达 —— 它们会以无主状态留在 Setup 页继续解析、无限重连,并持续把连接历史写进 IndexedDB。

三个 store 各导出 stop*,在置空分支统一关闭。

已接真实 mihomo 后端做端到端验证:触发置空后 lsof 显示 4 条 WS 立即关闭、tcpdump 10s 零数据包、无重连;重新选中后端后流正常重建。

(按 #723 的意见拆分,这是系列第 1 个;后续小 PR 会在此合并后按依赖顺序跟进)

🤖 Generated with [Claude Code](https://claude.com/claude-code)