### PR TITLE
perf: pause offscreen chart rendering, split static/data options

### DIFF
--- a/src/components/overview/BasicCharts.vue
+++ b/src/components/overview/BasicCharts.vue
@@ -54,20 +54,28 @@ const isPaused = ref(false)
 
 const { colorSet, fontFamily } = useChartColors(colorRef)
 
+// 静态骨架只随系列名集合变化;data 数组每拍换新引用,用 prev 保持返回值引用稳定,
+// 避免把整份静态 option 拖回每秒重算(那会退化成每拍全量 setOption)
+const seriesNames = computed<string[]>((prev) => {
+  const names = props.data.map((item) => item.name)
+
+  if (prev && prev.length === names.length && names.every((name, index) => name === prev[index])) {
+    return prev
+  }
+  return names
+})
+
+// 布局/样式/渐变等静态骨架:仅初始化与主题/字体/系列结构变化时下发。
+// 动画整体关闭:原 1s 线性过渡 × 1s 数据间隔 = 画布永远处于动画中、每帧重绘;
+// 时间窗锚定最新点后,曲线滚动观感由窗口平移承担,过渡动画只剩功耗
 const options = computed(() => {
   const isSeconds = props.xAxisMode === 'seconds'
-  // 时间窗锚定最新数据点,保证最新点钉在右缘;缓冲点落在左缘外被 clip 裁掉
-  const lastPoint = props.data[0]?.data.at(-1)
-  const latest = isSeconds
-    ? ((lastPoint as [number, number] | undefined)?.[0] ?? 0)
-    : ((lastPoint as HistoryPoint | undefined)?.name ?? Date.now())
 
   return {
-    animationDurationUpdate: 1000,
-    animationEasingUpdate: 'linear' as const,
+    animation: false,
     legend: {
       bottom: 0,
-      data: props.data.map((item) => item.name),
+      data: seriesNames.value,
       textStyle: {
         color: colorSet.baseContent,
         fontFamily: fontFamily.value,
@@ -95,8 +103,6 @@ const options = computed(() => {
     xAxis: isSeconds
       ? {
           type: 'value' as const,
-          min: latest - props.windowSec,
-          max: latest,
           axisLine: { show: false },
           axisTick: { show: false },
           splitLine: { show: false },
@@ -111,8 +117,6 @@ const options = computed(() => {
         }
       : {
           type: 'time' as const,
-          min: latest - (timeSaved - 1) * 1000,
-          max: latest - 1 * 1000,
           axisLine: { show: false },
           axisTick: { show: false },
           splitLine: { show: false },
@@ -145,12 +149,14 @@ const options = computed(() => {
         ...(isSeconds ? {} : { align: 'left' as const, padding: [0, 0, 0, -35] }),
       },
     },
-    series: props.data.map((item, index) => {
-      const seriesColor = index === props.data.length - 1 ? colorSet.primary60 : colorSet.info60
-      const areaColor = index === props.data.length - 1 ? colorSet.primary30 : colorSet.info30
+    series: seriesNames.value.map((name, index) => {
+      const seriesColor =
+        index === seriesNames.value.length - 1 ? colorSet.primary60 : colorSet.info60
+      const areaColor =
+        index === seriesNames.value.length - 1 ? colorSet.primary30 : colorSet.info30
 
       return {
-        name: item.name,
+        name,
         symbol: 'none',
         emphasis: {
           disabled: true,
@@ -158,7 +164,6 @@ const options = computed(() => {
         lineStyle: {
           width: 1,
         },
-        data: item.data,
         areaStyle: {
           color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
             {
@@ -179,5 +184,22 @@ const options = computed(() => {
   }
 })
 
-useEChartsInstance(chartRef, options, { isPaused })
+// 每拍只推各系列数据与轴时间窗;时间窗锚定最新数据点,保证最新点钉在右缘,
+// 缓冲点落在左缘外被 clip 裁掉
+const dataOptions = computed(() => {
+  const isSeconds = props.xAxisMode === 'seconds'
+  const lastPoint = props.data[0]?.data.at(-1)
+  const latest = isSeconds
+    ? ((lastPoint as [number, number] | undefined)?.[0] ?? 0)
+    : ((lastPoint as HistoryPoint | undefined)?.name ?? Date.now())
+
+  return {
+    xAxis: isSeconds
+      ? { min: latest - props.windowSec, max: latest }
+      : { min: latest - (timeSaved - 1) * 1000, max: latest - 1 * 1000 },
+    series: props.data.map((item) => ({ data: item.data })),
+  }
+})
+
+useEChartsInstance(chartRef, options, { isPaused, dataOptions })
 </script>

--- a/src/components/overview/MiniSparkline.vue
+++ b/src/components/overview/MiniSparkline.vue
@@ -37,13 +37,11 @@ const { colorSet, fontFamily } = useChartColors(colorRef)
 const seriesColor = computed(() => (props.color === 'info' ? colorSet.info60 : colorSet.primary60))
 const areaColor = computed(() => (props.color === 'info' ? colorSet.info30 : colorSet.primary30))
 
+// 静态骨架:仅初始化与主题/字体变化时下发;动画关闭(原 1s 过渡 × 1s 数据间隔
+// = 画布常驻逐帧重绘),曲线滚动观感由时间窗平移承担
 const options = computed(() => {
-  // 时间窗锚定最新数据点,保证最新点钉在右缘;缓冲点落在左缘外被 clip 裁掉
-  const latest = props.data.at(-1)?.name ?? Date.now()
-
   return {
-    animationDurationUpdate: 1000,
-    animationEasingUpdate: 'linear' as const,
+    animation: false,
     grid: { left: 0, top: 0, right: props.labelFormatter ? 30 : 0, bottom: 0 },
     tooltip: props.tooltipFormatter
       ? {
@@ -64,8 +62,6 @@ const options = computed(() => {
     xAxis: {
       type: 'time' as const,
       show: false,
-      min: latest - (timeSaved - 1) * 1000,
-      max: latest - 1 * 1000,
     },
     yAxis: {
       type: 'value' as const,
@@ -96,7 +92,6 @@ const options = computed(() => {
         symbol: 'none',
         smooth: true,
         lineStyle: { width: 1.5 },
-        data: props.data,
         color: seriesColor.value,
         emphasis: { disabled: true },
         areaStyle: {
@@ -110,5 +105,19 @@ const options = computed(() => {
   }
 })
 
-useEChartsInstance(chartRef, options)
+// 每拍只推数据与时间窗;时间窗锚定最新数据点,保证最新点钉在右缘,
+// 缓冲点落在左缘外被 clip 裁掉
+const dataOptions = computed(() => {
+  const latest = props.data.at(-1)?.name ?? Date.now()
+
+  return {
+    xAxis: {
+      min: latest - (timeSaved - 1) * 1000,
+      max: latest - 1 * 1000,
+    },
+    series: [{ data: props.data }],
+  }
+})
+
+useEChartsInstance(chartRef, options, { dataOptions })
 </script>

--- a/src/components/overview/TopologyCharts.vue
+++ b/src/components/overview/TopologyCharts.vue
@@ -102,7 +102,7 @@ import { SankeyChart } from 'echarts/charts'
 import { GridComponent, LegendComponent, TooltipComponent } from 'echarts/components'
 import * as echarts from 'echarts/core'
 import { CanvasRenderer } from 'echarts/renderers'
-import { debounce } from 'lodash'
+import { debounce, throttle } from 'lodash'
 import { twMerge } from 'tailwind-merge'
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -381,10 +381,23 @@ onMounted(() => {
     isPaused.value = false
   })
 
-  const updateChartData = debounce((newData: typeof sankeyData.value) => {
+  // 拓扑无需秒级刷新:throttle 3s(leading 立即出图)替代 debounce 300ms 的附加延迟;
+  // 结构签名相同的拍直接跳过 setOption(sankey 每次 render 全量销毁重建,空闲时是纯浪费)
+  let lastSignature = ''
+  const updateChartData = throttle((newData: typeof sankeyData.value) => {
     if (isPaused.value) {
       return
     }
+
+    const signature =
+      newData.nodes.map((node) => node.name).join(',') +
+      '|' +
+      newData.links.map((link) => `${link.source}>${link.target}:${link.value}`).join(',')
+
+    if (signature === lastSignature) {
+      return
+    }
+    lastSignature = signature
 
     if (myChart && newData.nodes.length > 0) {
       myChart.setOption(options.value)
@@ -411,9 +424,10 @@ onMounted(() => {
         }
       })
     }
-  }, 300)
+  }, 3000)
 
-  watch(sankeyData, updateChartData, { deep: true })
+  // computed 每拍必换新引用,deep 遍历纯属浪费
+  watch(sankeyData, updateChartData)
 
   watch([theme, font], () => {
     if (myChart) {

--- a/src/composables/useECharts.ts
+++ b/src/composables/useECharts.ts
@@ -1,6 +1,6 @@
 import { isMiddleScreen } from '@/helper/utils'
 import { font, theme } from '@/store/settings'
-import { useElementSize } from '@vueuse/core'
+import { useDocumentVisibility, useElementSize, useElementVisibility } from '@vueuse/core'
 import { LineChart } from 'echarts/charts'
 import { GridComponent, LegendComponent, TooltipComponent } from 'echarts/components'
 import * as echarts from 'echarts/core'
@@ -66,20 +66,64 @@ export const useChartColors = (colorRef: Ref<HTMLElement | undefined>) => {
 export const useEChartsInstance = <T extends echarts.EChartsCoreOption>(
   chartRef: Ref<HTMLElement | undefined>,
   options: ComputedRef<T>,
-  { isPaused }: { isPaused?: Ref<boolean> } = {},
+  {
+    isPaused,
+    dataOptions,
+  }: {
+    isPaused?: Ref<boolean>
+    // 秒级更新走这条数据通道(仅 series data / 轴时间窗),与 options 静态骨架分离:
+    // 骨架只在主题/字体/系列结构变化时才全量下发,免去每拍重建整棵 option 树再全量 merge
+    dataOptions?: ComputedRef<echarts.EChartsCoreOption>
+  } = {},
 ) => {
   let myChart: echarts.ECharts | null = null
   let touchEndHandler: ((e: TouchEvent) => void) | null = null
+
+  // 图表滚出视口或整页退到后台时暂停下发,回到可见补一拍最新值——
+  // 对不可见画布每秒 setOption + 重绘,挂机场景下是持续的 CPU/GPU 白耗
+  const chartVisible = useElementVisibility(chartRef)
+  const documentVisibility = useDocumentVisibility()
+  let pendingStatic = false
+  let pendingData = false
+
+  const hidden = () => !chartVisible.value || documentVisibility.value !== 'visible'
+
+  const applyStatic = () => {
+    if (!myChart) return
+    if (hidden()) {
+      pendingStatic = true
+      return
+    }
+    pendingStatic = false
+    myChart.setOption(options.value)
+  }
+
+  const applyData = () => {
+    if (!myChart || !dataOptions) return
+    if (isPaused?.value) return
+    if (hidden()) {
+      pendingData = true
+      return
+    }
+    pendingData = false
+    myChart.setOption(dataOptions.value, { lazyUpdate: true })
+  }
 
   onMounted(() => {
     if (!chartRef.value) return
 
     myChart = echarts.init(chartRef.value)
     myChart.setOption(options.value)
+    applyData()
 
-    watch(options, () => {
-      if (isPaused?.value) return
-      myChart?.setOption(options.value)
+    watch(options, applyStatic)
+    if (dataOptions) {
+      watch(dataOptions, applyData)
+    }
+    watch([chartVisible, documentVisibility], () => {
+      if (hidden()) return
+      if (pendingStatic) applyStatic()
+      if (pendingData) applyData()
     })
 
     const { width } = useElementSize(chartRef)


### PR DESCRIPTION
系列 3/8(继 #724、#727)。主题:**图表在没人看的时候(离屏/后台)白烧的渲染开销**。4 个文件,+125/-36。

> **评审调整**:采纳 review 意见,后台停流已整体撤出本 PR——隐藏期间三条秒级流照常接收、store 照常更新,**数据一个点都不丢**;现在只暂停不可见画布的 setOption/重绘,切回前台立即补一拍,图表直接显示**包含隐藏期在内的完整曲线**。"挂后台测速/下载、切回来看曲线"的场景完整支持。
> 同时 rebase 到最新 main:原分支基于后来被回退的 `chore: upgrade deps`,PR diff 里混入了 lockfile 等噪音,现在是干净的 4 个文件。

## 问题

**1. 动画常驻逐帧重绘**
`animationDurationUpdate: 1000` 的线性过渡 × 每秒一拍数据 = 过渡动画恰好铺满整个更新间隔,画布**永远处于动画中**,以 60fps 持续重绘。概览页常驻 7-8 个 ECharts 实例(3 张卡片 sparkline、侧栏 3 张、大图、拓扑),这是面板空闲功耗的最大单项。时间窗已锚定最新数据点,曲线滚动观感由窗口平移承担,过渡动画只剩功耗成本。

**2. 每拍全量重建整棵 option 树**
`options` 是单个 computed,data 数组每拍换新引用 → 每秒把 legend/tooltip/双轴/渐变对象全部重建一遍,再交给 setOption 做全量 merge。数据通道实际只需要 `series[].data` + 轴时间窗两项。

**3. 不可见时照常渲染**
图表滚出视口、或标签页切后台,每秒 setOption + 重绘照常执行,对不可见画布是纯浪费。

## 修改

- **useECharts**:新增可选的 `dataOptions` 数据通道(`lazyUpdate` 下发),与静态骨架分离;`useElementVisibility` + `useDocumentVisibility` 门控——不可见时跳过下发并记 pending,回到可见补一拍最新值(**流与 store 不受影响,数据完整**)。不传 `dataOptions` 的调用方行为不变,自动获得可见性门控。
- **BasicCharts / MiniSparkline**:option 拆为静态骨架(仅 init 与主题/字体/系列结构变化时下发)+ 数据通道(每拍);`seriesNames` 用 `computed(prev)` 保持引用稳定,防止 data 数组每拍的新引用把静态骨架拖回每秒重算;`animation: false`。
- **TopologyCharts**:throttle 3s(leading,立即出图)替代 debounce 300ms(拓扑无需秒级刷新,且 debounce 在持续数据流下始终附加延迟);去掉对每拍新引用 computed 的 `deep` watch;sankey 结构签名(节点+链路+值)不变的拍直接跳过 setOption(sankey 每次 setOption 全量销毁重建图元)。

## 收益

- 空闲挂机(图表离屏或标签页在后台)时:每秒 8 次全量 option 构建 + 8 个画布 60fps 动画重绘 → **0**;
- 前台正常观看时:每拍从"整棵 option 树重建 + 全量 merge"降为"两个小对象 + lazyUpdate",动画关闭后每秒只重绘一帧;
- 低端设备收益最大(动画逐帧重绘正是弱 CPU/GPU 卡顿的主因)。

## 行为变化(透明列出)

1. 曲线不再有 1s 滑动过渡,改为每秒步进一格(时间窗锚定右缘,无跳变);
2. 暂停播放期间切主题,图表颜色现在立即更新(原先要等恢复后下一拍)。

## 验证

- `vite build` / `eslint` / `prettier` 通过;`vue-tsc` 上我们 4 个文件零错误(当前 main 的 `SourceIPInput.vue` 存在 7 个与本 PR 无关的既有类型错误,deps 回退后遗留,可另行处理);
- 接真实 mihomo 后端(百余条连接)烟测:8 个图表渲染与秒级更新正常、暂停按钮正常、主题切换正常、tooltip 正常;
- hidden/visible 切换实测:隐藏期间流照常接收(store 引用持续更新),画布零下发;回前台 1 拍内补齐,曲线含隐藏窗口完整显示;
- 393×852 移动视口(触摸模拟)全页面过检:概览/代理/连接/日志/规则/设置正常,dock 快速连续切页零错误。

🤖 Generated with [Claude Code](https://claude.com/claude-code)